### PR TITLE
Bump Security Patch Level to 2018-07-01

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -81,7 +81,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
   # Can be an arbitrary string, but must be a single word.
   #
   # If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-  PLATFORM_SECURITY_PATCH := 2018-06-01
+  PLATFORM_SECURITY_PATCH := 2018-07-01
 endif
 
 ifeq "" "$(BUILD_ID)"


### PR DESCRIPTION
Reference version: 6.0.1

Implemented Patches
===================
CVE-2018-9412   A-78029004      High      Change 220497
CVE-2018-9421   A-77237570      High      Change 220498
CVE-2018-9365   A-74121126      Critical  Change 220504
CVE-2018-9432   A-73173182      High      Change 220502
CVE-2018-9420   A-77238656      High      Change 220503
CVE-2018-9376   A-69981755      Moderate
CVE-2018-9434   A-29833520 [1]  Moderate  Change 220500
CVE-2018-9434   A-29833520 [2]  Moderate  Change 220499
CVE-2018-9430   A-73963551      Moderate  Change 220505
CVE-2018-9414   A-78787521      Moderate  Change 220501

Skipped Patches
===============
CVE-2018-9433   A-38196219*     Critical  Not publicly available

Change-Id: I1963c50ef9679fc575b1186d5f074fa35dbe340a